### PR TITLE
Removed the -j4 option for make on Direwolf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone --depth 1 https://github.com/wb2osz/direwolf.git && \
     mkdir -p direwolf/build && \
     cd direwolf/build && \
     cmake ../ -DCMAKE_INSTALL_PREFIX=/root/target/usr/local && \
-    make -j4 && \
+    make && \
     make install
 
 


### PR DESCRIPTION
There's some problem with multi-arch container building on github, where the amd64 container compiling Direwolf seg faults. I can't reproduce on any other amd64 hardware. I'm just stabbing in the dark, but maybe removing the -j4 option on Make will slow things down enough where it can compile.

  [linux/arm64 build 4/4] RUN git clone --depth 1 https://github.com/wb2osz/direwolf.git &&     mkdir -p direwolf/build &&     cd direwolf/build &&     cmake ../ -DCMAKE_INSTALL_PREFIX=/root/target/usr/local &&     make -j4 &&     make install:
625.1 [ 81%] Building C object src/CMakeFiles/direwolf.dir/hdlc_rec.c.o
625.2 [ 81%] Building C object src/CMakeFiles/direwolf.dir/hdlc_rec2.c.o
626.6 [ 82%] Building C object src/CMakeFiles/direwolf.dir/hdlc_send.c.o
627.0 cc: internal compiler error: Segmentation fault signal terminated program cc1
627.0 Please submit a full bug report, with preprocessed source (by using -freport-bug).
627.0 See <file:///usr/share/doc/gcc-12/README.Bugs> for instructions.
627.1 make[2]: *** [src/CMakeFiles/direwolf.dir/build.make:552: src/CMakeFiles/direwolf.dir/hdlc_send.c.o] Error 4
627.1 make[2]: *** Waiting for unfinished jobs....
632.6 make[1]: *** [CMakeFiles/Makefile2:399: src/CMakeFiles/direwolf.dir/all] Error 2
632.6 make: *** [Makefile:156: all] Error 2

Dockerfile:25

  24 |     # Build and install Direwolf into /root/target/usr/local
  25 | >>> RUN git clone --depth 1 https://github.com/wb2osz/direwolf.git && \
  26 | >>>     mkdir -p direwolf/build && \
  27 | >>>     cd direwolf/build && \
  28 | >>>     cmake ../ -DCMAKE_INSTALL_PREFIX=/root/target/usr/local && \
  29 | >>>     make -j4 && \
  30 | >>>     make install
  31 |     

ERROR: failed to solve: process "/bin/sh -c git clone --depth 1 https://github.com/wb2osz/direwolf.git &&     mkdir -p direwolf/build &&     cd direwolf/build &&     cmake ../ -DCMAKE_INSTALL_PREFIX=/root/target/usr/local &&     make -j4 &&     make install" did not complete successfully: exit code: 2
Reference
Check build summary support
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c git clone --depth 1 https://github.com/wb2osz/direwolf.git &&     mkdir -p direwolf/build &&     cd direwolf/build &&     cmake ../ -DCMAKE_INSTALL_PREFIX=/root/target/usr/local &&     make -j4 &&     make install" did not complete successfully: exit code: 2