### PR TITLE
Splitting the arm64 build out into it's own action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,12 +32,25 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.RTLAPRSIGATE_CLASSIC_TOKEN }}
 
+# Need to split the arm64 build into it's own action because Direwolf seg faults when compiling
     - name: Build and push to ghcr
       uses: docker/build-push-action@v6
       with:
         context: .
         file: ./Dockerfile
-        platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v6,linux/arm/v7
+        platforms: linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=APRS Igate using RTL-SDR dongle
+        tags: |
+          ghcr.io/bklofas/rtl-aprs-igate:latest
+          ghcr.io/bklofas/rtl-aprs-igate:${{ github.ref_name }}
+    
+    - name: Build and push to ghcr
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/386,linux/arm/v6,linux/arm/v7
         push: ${{ github.event_name != 'pull_request' }}
         outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=APRS Igate using RTL-SDR dongle
         tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone --depth 1 https://github.com/wb2osz/direwolf.git && \
     mkdir -p direwolf/build && \
     cd direwolf/build && \
     cmake ../ -DCMAKE_INSTALL_PREFIX=/root/target/usr/local && \
-    make && \
+    make -j4 && \
     make install
 
 


### PR DESCRIPTION
Trying to bypass the compile segmentation fault during Direwolf compliation by splitting the arm64 build out into it's own action.